### PR TITLE
Update README scrum docs sprint 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ The deliverable documents for group PixelPerfect are included in the docs direct
 * [Sprint Backlog #1 (22-04-2016)](https://github.com/jessetilro/pixelperfect/blob/master/docs/sprint-backlog-1.pdf)
 * [Sprint Retrospective #1 (29-04-2016)](https://github.com/jessetilro/pixelperfect/blob/master/docs/sprint-retrospective-1.pdf)
 * [Sprint Backlog #2 (29-04-2016)](https://github.com/jessetilro/pixelperfect/blob/master/docs/sprint-backlog-2.pdf)
+* [Sprint Retrospective #2 (06-05-2016)](https://github.com/jessetilro/pixelperfect/blob/master/docs/sprint-retrospective-2.pdf)
+* [Sprint Backlog #3 (06-05-2016)](https://github.com/jessetilro/pixelperfect/blob/master/docs/sprint-backlog-3.pdf)


### PR DESCRIPTION
Updated the README.md to contain references to the Sprint Retrospective 2 and Sprint Backlog 3 SCRUM deliverable documents.