### PR TITLE
Update POM to reduce build load.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,16 +15,6 @@
       <name>bintray</name>
       <url>http://dl.bintray.com/jmonkeyengine/org.jmonkeyengine</url>
     </repository>
-  
-    <repository>
-        <id>jmonkeyengine-repository</id>
-        <url>http://updates.jmonkeyengine.org/maven/</url>
-    </repository>
-    
-    <repository>
-        <id>jessetilro-repository</id>
-        <url>http://maven.jessetilro.nl/</url>
-    </repository>
   </repositories>
 
   <dependencies>
@@ -73,12 +63,6 @@
     	<groupId>org.jmonkeyengine</groupId>
     	<artifactId>jme3-networking</artifactId>
     	<version>3.1.0-alpha5</version>
-    </dependency>
-    
-    <dependency>
-        <groupId>nl.tudelft.pixelperfect</groupId>
-        <artifactId>jmonkeyvr</artifactId>
-        <version>1.0.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Updated the POM, removed some repositories / dependencies in order to
hopefully reduce the load in the build server (given that the jme
repository is offline).