### PR TITLE
Fix CheckStyle error in Constants.

### DIFF
--- a/src/main/java/nl/tudelft/pixelperfect/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/Constants.java
@@ -7,10 +7,17 @@ package nl.tudelft.pixelperfect;
  *
  */
 public final class Constants {
+
+  /**
+   * Empty private constructor, since this is a utility class.
+   */
+  private Constants() {
+  }
+
   // Gui-styling related constants for the in-game HUD.
   public static final int GUI_WIDTH_OFFSET = 150;
   public static final int GUI_HEIGHT_OFFSET = 50;
-  
+
   // Gui text for the in-game HUd.
   public static final String NO_EVENTS_LOG_TEXT = "Everything looks clear, cap'n!";
 }


### PR DESCRIPTION
The Constants Utility class contained a static error: it should not have a
public or default constructor.