### PR TITLE
Event scheduler update

### DIFF
--- a/src/main/java/nl/tudelft/pixelperfect/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/Constants.java
@@ -26,5 +26,6 @@ public final class Constants {
   public static final String SHIP_HEALTH_LABEL = "Health: ";
 
   // Target intensity for the Event Scheduler.
-  public static final double EVENT_SCHEDULER_INTENSITY = 0.125;
+  public static final double EVENT_SCHEDULER_INTENSITY_MIN = 0.125;
+  public static final double EVENT_SCHEDULER_INTENSITY_MAX = 0.5;
 }

--- a/src/main/java/nl/tudelft/pixelperfect/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/Constants.java
@@ -17,11 +17,14 @@ public final class Constants {
   // Gui-styling related constants for the in-game HUD.
   public static final int GUI_LOG_WIDTH_OFFSET = 150;
   public static final int GUI_LOG_HEIGHT_OFFSET = 50;
-  
+
   public static final int GUI_HEALTH_WIDTH_OFFSET = 300;
   public static final int GUI_HEALTH_HEIGHT_OFFSET = 100;
 
   // Gui text for the in-game HUd.
   public static final String NO_EVENTS_LOG_TEXT = "Everything looks clear, cap'n!";
   public static final String SHIP_HEALTH_LABEL = "Health: ";
+
+  // Target intensity for the Event Scheduler.
+  public static final double EVENT_SCHEDULER_INTENSITY = 0.125;
 }

--- a/src/main/java/nl/tudelft/pixelperfect/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/Game.java
@@ -99,7 +99,8 @@ public class Game extends VRApplication {
 
     spaceship = new Spaceship();
     spaceship.getLog().setServer(server);
-    scheduler = new EventScheduler(Constants.EVENT_SCHEDULER_INTENSITY);
+    scheduler = new EventScheduler(Constants.EVENT_SCHEDULER_INTENSITY_MIN,
+        Constants.EVENT_SCHEDULER_INTENSITY_MAX);
     scheduler.subscribe(spaceship.getLog());
     scheduler.start();
 

--- a/src/main/java/nl/tudelft/pixelperfect/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/Game.java
@@ -1,5 +1,7 @@
 package nl.tudelft.pixelperfect;
 
+import java.io.IOException;
+
 import com.jme3.input.InputManager;
 import com.jme3.input.KeyInput;
 import com.jme3.input.controls.ActionListener;
@@ -12,7 +14,6 @@ import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;
 
 import jmevr.app.VRApplication;
-
 import nl.tudelft.pixelperfect.client.ConnectListener;
 import nl.tudelft.pixelperfect.client.EventCompletedMessage;
 import nl.tudelft.pixelperfect.client.EventsMessage;
@@ -20,9 +21,6 @@ import nl.tudelft.pixelperfect.client.ServerListener;
 import nl.tudelft.pixelperfect.event.Event;
 import nl.tudelft.pixelperfect.event.EventScheduler;
 import nl.tudelft.pixelperfect.gui.GameHeadsUpDisplay;
-
-import java.io.IOException;
-
 
 /**
  * Main class representing an active Game process and creating the JMonkey Environment.
@@ -101,7 +99,7 @@ public class Game extends VRApplication {
 
     spaceship = new Spaceship();
     spaceship.getLog().setServer(server);
-    scheduler = new EventScheduler(0.5);
+    scheduler = new EventScheduler(Constants.EVENT_SCHEDULER_INTENSITY);
     scheduler.subscribe(spaceship.getLog());
 
     gameHud = new GameHeadsUpDisplay(getAssetManager(), guiNode, 200, 200, spaceship);
@@ -149,7 +147,7 @@ public class Game extends VRApplication {
         }
       }
     };
-    String[] mappings = {"forward", "back", "left", "right"};
+    String[] mappings = { "forward", "back", "left", "right" };
     for (String mapping : mappings) {
       inputManager.addListener(acl, mapping);
     }
@@ -168,7 +166,7 @@ public class Game extends VRApplication {
    * Main update loop for the game.
    */
   @Override
-  @SuppressWarnings({ "checkstyle:methodlength"})
+  @SuppressWarnings({ "checkstyle:methodlength" })
   public void simpleUpdate(float tpf) {
     if (moveForward) {
       observer.move(VRApplication.getFinalObserverRotation().getRotationColumn(2).mult(tpf * 8f));
@@ -183,7 +181,7 @@ public class Game extends VRApplication {
       observer.rotate(0, -0.75f * tpf, 0);
     }
 
-    scheduler.update(tpf / 8);
+    scheduler.update(tpf);
     spaceship.update(tpf);
 
     // Update the in-game heads up display.

--- a/src/main/java/nl/tudelft/pixelperfect/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/Game.java
@@ -101,6 +101,7 @@ public class Game extends VRApplication {
     spaceship.getLog().setServer(server);
     scheduler = new EventScheduler(Constants.EVENT_SCHEDULER_INTENSITY);
     scheduler.subscribe(spaceship.getLog());
+    scheduler.start();
 
     gameHud = new GameHeadsUpDisplay(getAssetManager(), guiNode, 200, 200, spaceship);
   }

--- a/src/main/java/nl/tudelft/pixelperfect/event/EventScheduler.java
+++ b/src/main/java/nl/tudelft/pixelperfect/event/EventScheduler.java
@@ -107,6 +107,10 @@ public class EventScheduler {
    * Update the intensity percentage representing what the current intensity should be with respect
    * to the predefined minimum and maximum intensities. Zero meaning minimum intensity and one
    * hundred meaning maximum intensity.
+   * 
+   * @param intensityPercentage
+   *          A percentage between zero and one hundred percent used to linearly interpolate between
+   *          the predefined minimum and maximum intensities.
    */
   public void updateIntensity(double intensityPercentage) {
     if (intensityPercentage > 1) {

--- a/src/main/java/nl/tudelft/pixelperfect/event/EventScheduler.java
+++ b/src/main/java/nl/tudelft/pixelperfect/event/EventScheduler.java
@@ -16,6 +16,7 @@ public class EventScheduler {
   private double intensity;
   private ArrayList<EventListener> listeners;
   private EventFactory factory;
+  private boolean active;
 
   /**
    * Construct a new EventScheduler instance.
@@ -27,6 +28,21 @@ public class EventScheduler {
     this.intensity = intensity;
     this.listeners = new ArrayList<EventListener>();
     this.factory = new EventFactory();
+    this.active = false;
+  }
+
+  /**
+   * Allow the Scheduler to resume scheduling events by making it active.
+   */
+  public void start() {
+    active = true;
+  }
+
+  /**
+   * Disallow the Scheduler to schedule any event by making it inactive.
+   */
+  public void stop() {
+    active = false;
   }
 
   /**
@@ -60,6 +76,9 @@ public class EventScheduler {
    *          process.
    */
   public void update(float tpf) {
+    if (!active) {
+      return;
+    }
     // The random generator should be more efficient and less biased than the Math.random function.
     Random rg = new Random();
 

--- a/src/main/java/nl/tudelft/pixelperfect/event/EventScheduler.java
+++ b/src/main/java/nl/tudelft/pixelperfect/event/EventScheduler.java
@@ -13,19 +13,45 @@ import java.util.Random;
  */
 public class EventScheduler {
 
-  private double intensity;
+  private double intensityMin;
+  private double intensityMax;
+  private double intensityPercentage;
   private ArrayList<EventListener> listeners;
   private EventFactory factory;
   private boolean active;
 
   /**
-   * Construct a new EventScheduler instance.
+   * Construct a new EventScheduler instance with an intensity varying between a given minimum and
+   * maximum.
+   * 
+   * @param intensityMin
+   *          The minimum average number of events introduced per second in the game.
+   * @param intensityMax
+   *          The minimum average number of events introduced per second in the game.
+   */
+  public EventScheduler(double intensityMin, double intensityMax) {
+    this.intensityMin = intensityMin;
+    this.intensityMax = intensityMax;
+    construct();
+  }
+
+  /**
+   * Construct a new EventScheduler instance with a fixed intensity.
    * 
    * @param intensity
    *          The average number of events introduced per second in the game.
    */
   public EventScheduler(double intensity) {
-    this.intensity = intensity;
+    this.intensityMin = intensity;
+    this.intensityMax = intensity;
+    construct();
+  }
+
+  /**
+   * Repeated part of the constructors.
+   */
+  private void construct() {
+    this.intensityPercentage = 0;
     this.listeners = new ArrayList<EventListener>();
     this.factory = new EventFactory();
     this.active = false;
@@ -68,6 +94,31 @@ public class EventScheduler {
   }
 
   /**
+   * Compute the intensity based on the minimum and maximum intensities in combination with the
+   * intensity percentage.
+   * 
+   * @return The current intensity.
+   */
+  private double getIntensity() {
+    return intensityMin + intensityPercentage * (intensityMax - intensityMin);
+  }
+
+  /**
+   * Update the intensity percentage representing what the current intensity should be with respect
+   * to the predefined minimum and maximum intensities. Zero meaning minimum intensity and one
+   * hundred meaning maximum intensity.
+   */
+  public void updateIntensity(double intensityPercentage) {
+    if (intensityPercentage > 1) {
+      this.intensityPercentage = 1;
+    } else if (intensityPercentage < 0) {
+      this.intensityPercentage = 0;
+    } else {
+      this.intensityPercentage = intensityPercentage;
+    }
+  }
+
+  /**
    * With a given probability, introduce a new random event for the next step in the game loop. This
    * models a poisson process, with the specified intensity as lambda parameter.
    * 
@@ -84,7 +135,7 @@ public class EventScheduler {
 
     // The tpf is expressed in seconds, therefore intensity times tpf represents the expected value
     // of the probability distribution.
-    double mu = intensity * tpf;
+    double mu = getIntensity() * tpf;
     double pzero = Math.exp(-mu);
     int kvalue = 0;
     double pvalue = 1.0;

--- a/src/test/java/nl/tudelft/pixelperfect/event/EventSchedulerTest.java
+++ b/src/test/java/nl/tudelft/pixelperfect/event/EventSchedulerTest.java
@@ -28,11 +28,14 @@ public class EventSchedulerTest {
 
   private static int sampleSize = 20000;
   private static float duration = 4;
-  private double intensity;
+  private static double intensityPercentage = 0.5;
+  private double intensityMin;
+  private double intensityMax;
   private double percentage;
 
   private EventListener mockedListener;
   private EventScheduler object;
+  private EventScheduler objectVariable;
 
   /**
    * Construct a new parameterized test suite for the EventScheduler class.
@@ -43,8 +46,9 @@ public class EventSchedulerTest {
    *          The percentage of events the sample mean can deviate from the expected value (after
    *          multiplication with the sample size).
    */
-  public EventSchedulerTest(double intensity, double percentage) {
-    this.intensity = intensity;
+  public EventSchedulerTest(double intensityMin, double intensityMax, double percentage) {
+    this.intensityMin = intensityMin;
+    this.intensityMax = intensityMax;
     this.percentage = percentage;
   }
 
@@ -53,26 +57,30 @@ public class EventSchedulerTest {
    */
   @Before
   public void init() {
-    object = new EventScheduler(intensity);
+    object = new EventScheduler(intensityMin);
+    objectVariable = new EventScheduler(intensityMin, intensityMax);
     mockedListener = mock(EventLog.class);
 
     object.subscribe(mockedListener);
+    objectVariable.subscribe(mockedListener);
   }
 
   /**
-   * When the scheduler is started, the number of events it will subsequently schedule must be
-   * within an expected range.
+   * When the (fixed intensity) scheduler is started, the number of events it will subsequently
+   * schedule must be within an expected range. Furthermore updating the intensity on such a
+   * scheduler should have no effect.
    */
   @Test
   public void testUpdateStart() {
     // Fixtures
-    double expectedValue = intensity * duration;
+    double expectedValue = intensityMin * duration;
     int expectedEvents = (int) (expectedValue * sampleSize);
     int allowedDeviation = (int) (percentage * expectedEvents);
 
     // Execution
     object.start();
-    execute();
+    object.updateIntensity(0.42);
+    execute(object);
 
     // Verification
     verify(mockedListener, atLeast(expectedEvents - allowedDeviation)).notify(any(Event.class));
@@ -80,18 +88,83 @@ public class EventSchedulerTest {
   }
 
   /**
-   * When the scheduler is stopped, the number of events it will subsequently schedule must be 0,
-   * regardless of the intensity and time interval.
+   * When the (fixed intensity) scheduler is stopped, the number of events it will subsequently
+   * schedule must be 0, regardless of the intensity and time interval.
    */
   @Test
   public void testUpdateStop() {
     // Execution
     object.start();
     object.stop();
-    execute();
+    execute(object);
 
     // Verification
     verify(mockedListener, times(0)).notify(any(Event.class));
+  }
+
+  /**
+   * When updating the intensity on a variable intensity scheduler with a percentage lower than zero
+   * percent, it should use its predefined minimum intensity.
+   */
+  @Test
+  public void testUpdateIntensityLessThanZero() {
+    // Fixtures
+    double expectedValue = intensityMin * duration;
+    int expectedEvents = (int) (expectedValue * sampleSize);
+    int allowedDeviation = (int) (percentage * expectedEvents);
+
+    // Execution
+    objectVariable.updateIntensity(-0.42);
+    objectVariable.start();
+    execute(objectVariable);
+
+    // Verification
+    verify(mockedListener, atLeast(expectedEvents - allowedDeviation)).notify(any(Event.class));
+    verify(mockedListener, atMost(expectedEvents + allowedDeviation)).notify(any(Event.class));
+  }
+
+  /**
+   * When updating the intensity on a variable intensity scheduler with a percentage greater than
+   * one hundred percent, it should use its predefined maximum intensity.
+   */
+  @Test
+  public void testUpdateIntensityGreaterThanOneHundred() {
+    // Fixtures
+    double expectedValue = intensityMax * duration;
+    int expectedEvents = (int) (expectedValue * sampleSize);
+    int allowedDeviation = (int) (percentage * expectedEvents);
+
+    // Execution
+    objectVariable.updateIntensity(1.42);
+    objectVariable.start();
+    execute(objectVariable);
+
+    // Verification
+    verify(mockedListener, atLeast(expectedEvents - allowedDeviation)).notify(any(Event.class));
+    verify(mockedListener, atMost(expectedEvents + allowedDeviation)).notify(any(Event.class));
+  }
+
+  /**
+   * When updating the intensity on a variable intensity scheduler with a valid percentage between
+   * zero and one hundred percent, it should linearly interpolate correctly between minimum and
+   * maximum intensity.
+   */
+  @Test
+  public void testUpdateIntensity() {
+    // Fixtures
+    double targetIntensity = intensityMin + intensityPercentage * (intensityMax - intensityMin);
+    double expectedValue = targetIntensity * duration;
+    int expectedEvents = (int) (expectedValue * sampleSize);
+    int allowedDeviation = (int) (percentage * expectedEvents);
+
+    // Execution
+    objectVariable.updateIntensity(intensityPercentage);
+    objectVariable.start();
+    execute(objectVariable);
+
+    // Verification
+    verify(mockedListener, atLeast(expectedEvents - allowedDeviation)).notify(any(Event.class));
+    verify(mockedListener, atMost(expectedEvents + allowedDeviation)).notify(any(Event.class));
   }
 
   /**
@@ -102,7 +175,7 @@ public class EventSchedulerTest {
    * 0. That's what we will use to test the Poisson process, while testing it with different
    * parameters.
    */
-  public void execute() {
+  private void execute(EventScheduler object) {
     for (int i = 0; i < sampleSize; i++) {
       object.update(duration);
     }
@@ -115,8 +188,8 @@ public class EventSchedulerTest {
    */
   @Parameters
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] { { 0, 0 }, { 0.2, 0.2 }, { 0.25, 0.2 }, { 0.5, 0.2 },
-        { 0.75, 0.2 }, { 0.9, 0.2 } });
+    return Arrays.asList(new Object[][] { { 0, 0, 0 }, { 0.2, 0.4, 0.2 }, { 0.25, 0.5, 0.2 },
+        { 0.5, 0.75, 0.2 }, { 0.75, 0.8, 0.2 }, { 0.9, 0.95, 0.2 } });
   }
 
 }

--- a/src/test/java/nl/tudelft/pixelperfect/event/EventSchedulerTest.java
+++ b/src/test/java/nl/tudelft/pixelperfect/event/EventSchedulerTest.java
@@ -40,8 +40,10 @@ public class EventSchedulerTest {
   /**
    * Construct a new parameterized test suite for the EventScheduler class.
    * 
-   * @param intensity
-   *          The average number of events generated per second by the Poisson process.
+   * @param intensityMin
+   *          The minimum average number of events generated per second by the Poisson process.
+   * @param intensityMax
+   *          The maximum average number of events generated per second by the Poisson process.
    * @param percentage
    *          The percentage of events the sample mean can deviate from the expected value (after
    *          multiplication with the sample size).


### PR DESCRIPTION
Updated the EventScheduler component. It can now:

- Resume and pause using start and stop methods.
- Update its intensity parameter with a call to the updateIntensity method. It takes a percentage that is used to linearly interpolate between a predefined minimum and maximum intensity.

Updated the test suite to reflect the changes.
The intensities used in the Game have been added to the Constants.
Resolves issues #153 and #154.