### PR TITLE
Fixed equals method

### DIFF
--- a/src/main/java/nl/tudelft/pixelperfect/player/Engineer.java
+++ b/src/main/java/nl/tudelft/pixelperfect/player/Engineer.java
@@ -29,7 +29,7 @@ public class Engineer extends CrewPlayer {
   @Override
   public boolean equals(Object that) {
     if (that instanceof Engineer) {
-      return super.equals(that) && ((Engineer) that).getName().equals(this.getName());
+      return super.equals(that);
     }
     return false;
   }

--- a/src/main/java/nl/tudelft/pixelperfect/player/Gunner.java
+++ b/src/main/java/nl/tudelft/pixelperfect/player/Gunner.java
@@ -28,7 +28,7 @@ public class Gunner extends CrewPlayer {
   @Override
   public boolean equals(Object that) {
     if (that instanceof Gunner) {
-      return super.equals(that) && ((Gunner) that).getName().equals(this.getName());
+      return super.equals(that);
     }
     return false;
   }

--- a/src/main/java/nl/tudelft/pixelperfect/player/Scientist.java
+++ b/src/main/java/nl/tudelft/pixelperfect/player/Scientist.java
@@ -29,7 +29,7 @@ public class Scientist extends CrewPlayer {
   @Override
   public boolean equals(Object that) {
     if (that instanceof Scientist) {
-      return super.equals(that) && ((Scientist) that).getName().equals(this.getName());
+      return super.equals(that);
     }
     return false;
   }

--- a/src/test/java/nl/tudelft/pixelperfect/event/EventTest.java
+++ b/src/test/java/nl/tudelft/pixelperfect/event/EventTest.java
@@ -102,4 +102,9 @@ public abstract class EventTest {
   public void testGetDamage() {
     assertEquals(99.42, toTest.getDamage(), 0.0);
   }
-}
+  
+  @Test
+  public void testGetTimeLeft() {
+    assertEquals(4, toTest.getTimeLeft(80L), 0.0);
+  }
+  }


### PR DESCRIPTION
The method used duplicate checks, causing unachievable branches.