### PR TITLE
Gui beta hud

### DIFF
--- a/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
@@ -15,23 +15,23 @@ public final class Constants {
   }
 
   // Gui-styling related constants for the in-game debug HUD.
-  public static final int GUI_LOG_WIDTH_OFFSET = 150;
-  public static final int GUI_LOG_HEIGHT_OFFSET = 50;
+  public static final int DEBUG_LOG_WIDTH_OFFSET = 150;
+  public static final int DEBUG_LOG_HEIGHT_OFFSET = 50;
 
-  public static final int GUI_HEALTH_WIDTH_OFFSET = 300;
-  public static final int GUI_HEALTH_HEIGHT_OFFSET = 100;
+  public static final int DEBUG_HEALTH_WIDTH_OFFSET = 300;
+  public static final int DEBUG_HEALTH_HEIGHT_OFFSET = 100;
 
-  public static final int GUI_SCORE_WIDTH_OFFSET = 400;
-  public static final int GUI_SCORE_HEIGHT_OFFSET = 150;
+  public static final int DEBUG_SCORE_WIDTH_OFFSET = 400;
+  public static final int DEBUG_SCORE_HEIGHT_OFFSET = 150;
 
-  public static final int GUI_TIME_WIDTH_OFFSET = 400;
-  public static final int GUI_TIME_HEIGHT_OFFSET = 0;
+  public static final int DEBUG_TIME_WIDTH_OFFSET = 400;
+  public static final int DEBUG_TIME_HEIGHT_OFFSET = 0;
 
   // Gui text for the in-game debug HUD.
-  public static final String NO_EVENTS_LOG_TEXT = "No events currently active.";
-  public static final String SHIP_HEALTH_LABEL = "Health: ";
-  public static final String SHIP_SCORE_LABEL = "Score: ";
-  public static final String SHIP_TIME_LABEL = "Time: ";
+  public static final String DEBUG_NO_EVENTS_LOG_TEXT = "No events currently active";
+  public static final String DEBUG_SHIP_HEALTH_LABEL = "Health: ";
+  public static final String DEBUG_SHIP_SCORE_LABEL = "Score: ";
+  public static final String DEBUG_SHIP_TIME_LABEL = "Time: ";
 
   // Target intensity for the Event Scheduler.
   public static final double EVENT_SCHEDULER_INTENSITY_MIN = 0.125;

--- a/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
@@ -35,8 +35,8 @@ public final class Constants {
   public static final String DEBUG_SHIP_TIME_LABEL = "Time: ";
 
   // Positioning and scaling related constants for the in-game HUD.
-  public static final int GUI_LOG_WIDTH_OFFSET = 500;
-  public static final int GUI_LOG_HEIGHT_OFFSET = 150;
+  public static final int GUI_LOG_WIDTH_OFFSET = 925;
+  public static final int GUI_LOG_HEIGHT_OFFSET = 0;
 
   public static final int GUI_HEALTH_WIDTH_OFFSET = 1700;
   

--- a/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
@@ -34,15 +34,17 @@ public final class Constants {
   public static final String DEBUG_SHIP_SCORE_LABEL = "Score: ";
   public static final String DEBUG_SHIP_TIME_LABEL = "Time: ";
 
-  // Positioning related constants for the in-game HUD.
+  // Positioning and scaling related constants for the in-game HUD.
   public static final int GUI_LOG_WIDTH_OFFSET = 0;
   public static final int GUI_LOG_HEIGHT_OFFSET = 0;
 
   public static final int GUI_HEALTH_WIDTH_OFFSET = 0;
   public static final int GUI_HEALTH_HEIGHT_OFFSET = 0;
+  public static final int GUI_HEALTH_TEXT_SIZE_SCALE = 2;
 
   public static final int GUI_SCORE_WIDTH_OFFSET = 0;
   public static final int GUI_SCORE_HEIGHT_OFFSET = 0;
+  public static final int GUI_SCORE_TEXT_SIZE_SCALE = 2;
 
   // Target intensity for the Event Scheduler.
   public static final double EVENT_SCHEDULER_INTENSITY_MIN = 0.125;

--- a/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
@@ -4,17 +4,18 @@ package nl.tudelft.pixelperfect.game;
  * A data class for storing game-wide items that can all be altered in a single sweep.
  * 
  * @author David Alderliesten
+ * @author Jesse Tilro
  *
  */
 public final class Constants {
 
   /**
-   * Empty private constructor, since this is a utility class.
+   * Empty private constructor, since this is a data/utility class.
    */
   private Constants() {
   }
 
-  // Gui-styling related constants for the in-game debug HUD.
+  // Positioning related constants for the in-game debug HUD.
   public static final int DEBUG_LOG_WIDTH_OFFSET = 150;
   public static final int DEBUG_LOG_HEIGHT_OFFSET = 50;
 
@@ -27,11 +28,21 @@ public final class Constants {
   public static final int DEBUG_TIME_WIDTH_OFFSET = 400;
   public static final int DEBUG_TIME_HEIGHT_OFFSET = 0;
 
-  // Gui text for the in-game debug HUD.
+  // Text constants for the in-game debug HUD.
   public static final String DEBUG_NO_EVENTS_LOG_TEXT = "No events currently active";
   public static final String DEBUG_SHIP_HEALTH_LABEL = "Health: ";
   public static final String DEBUG_SHIP_SCORE_LABEL = "Score: ";
   public static final String DEBUG_SHIP_TIME_LABEL = "Time: ";
+
+  // Positioning related constants for the in-game HUD.
+  public static final int GUI_LOG_WIDTH_OFFSET = 0;
+  public static final int GUI_LOG_HEIGHT_OFFSET = 0;
+
+  public static final int GUI_HEALTH_WIDTH_OFFSET = 0;
+  public static final int GUI_HEALTH_HEIGHT_OFFSET = 0;
+
+  public static final int GUI_SCORE_WIDTH_OFFSET = 0;
+  public static final int GUI_SCORE_HEIGHT_OFFSET = 0;
 
   // Target intensity for the Event Scheduler.
   public static final double EVENT_SCHEDULER_INTENSITY_MIN = 0.125;

--- a/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
@@ -35,15 +35,12 @@ public final class Constants {
   public static final String DEBUG_SHIP_TIME_LABEL = "Time: ";
 
   // Positioning and scaling related constants for the in-game HUD.
-  public static final int GUI_LOG_WIDTH_OFFSET = 0;
-  public static final int GUI_LOG_HEIGHT_OFFSET = 0;
+  public static final int GUI_LOG_WIDTH_OFFSET = 500;
+  public static final int GUI_LOG_HEIGHT_OFFSET = 150;
 
   public static final int GUI_HEALTH_WIDTH_OFFSET = 1700;
-  public static final int GUI_HEALTH_HEIGHT_OFFSET = 0;
+  
   public static final int GUI_HEALTH_TEXT_SIZE_SCALE = 2;
-
-  public static final int GUI_SCORE_WIDTH_OFFSET = 0;
-  public static final int GUI_SCORE_HEIGHT_OFFSET = 0;
   public static final int GUI_SCORE_TEXT_SIZE_SCALE = 2;
 
   // Target intensity for the Event Scheduler.

--- a/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
@@ -35,9 +35,7 @@ public final class Constants {
   public static final String DEBUG_SHIP_TIME_LABEL = "Time: ";
 
   // Positioning and scaling related constants for the in-game HUD.
-  public static final int GUI_LOG_WIDTH_OFFSET = 925;
-  public static final int GUI_LOG_HEIGHT_OFFSET = 0;
-
+  public static final int GUI_LOG_WIDTH_OFFSET = 1000;
   public static final int GUI_HEALTH_WIDTH_OFFSET = 1700;
   
   public static final int GUI_HEALTH_TEXT_SIZE_SCALE = 2;

--- a/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Constants.java
@@ -38,7 +38,7 @@ public final class Constants {
   public static final int GUI_LOG_WIDTH_OFFSET = 0;
   public static final int GUI_LOG_HEIGHT_OFFSET = 0;
 
-  public static final int GUI_HEALTH_WIDTH_OFFSET = 0;
+  public static final int GUI_HEALTH_WIDTH_OFFSET = 1700;
   public static final int GUI_HEALTH_HEIGHT_OFFSET = 0;
   public static final int GUI_HEALTH_TEXT_SIZE_SCALE = 2;
 

--- a/src/main/java/nl/tudelft/pixelperfect/game/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Game.java
@@ -42,7 +42,7 @@ public class Game extends VRApplication {
   private Spaceship spaceship;
   private EventScheduler scheduler;
   private Server server;
-  private AudioPlayer audioPlayer;
+  //private AudioPlayer audioPlayer;
 
   private Spatial observer;
 
@@ -110,7 +110,7 @@ public class Game extends VRApplication {
     scene = new Scene(this);
     scene.createMap();
 
-    audioPlayer = new AudioPlayer(this);
+    //audioPlayer = new AudioPlayer(this);
     // String[] names = {};
     // String[] locations = {};
     // audioPlayer.loadSounds(names, locations);

--- a/src/main/java/nl/tudelft/pixelperfect/game/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Game.java
@@ -111,10 +111,9 @@ public class Game extends VRApplication {
     scene.createMap();
 
     audioPlayer = new AudioPlayer(this);
-    // TODO load actual sounds
-    String[] names = {};
-    String[] locations = {};
-    audioPlayer.loadSounds(names, locations);
+    // String[] names = {};
+    // String[] locations = {};
+    // audioPlayer.loadSounds(names, locations);
 
     initNetwork();
 

--- a/src/main/java/nl/tudelft/pixelperfect/game/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Game.java
@@ -126,7 +126,7 @@ public class Game extends VRApplication {
     scheduler.start();
 
     debugHud = new DebugHeadsUpDisplay(getAssetManager(), guiNode, 200, 200, spaceship);
-    gameHud = new GameHeadsUpDisplay(getAssetManager(), guiNode, 1800, 1050, spaceship);
+    gameHud = new GameHeadsUpDisplay(getAssetManager(), guiNode, 1800, 1000, spaceship);
 
     gameState = new StartState(this);
   }

--- a/src/main/java/nl/tudelft/pixelperfect/game/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Game.java
@@ -310,13 +310,23 @@ public class Game extends VRApplication {
   }
 
   /**
-   * Setter for headsUpDisplay.
+   * Setter for debugDisplay.
    *
-   * @param headsUpDisplay
-   *          HeadsUpDisplay to be set.
+   * @param debugDisplay
+   *          debugDisplay to be set.
    */
-  public void setHeadsUpDisplay(DebugHeadsUpDisplay headsUpDisplay) {
-    this.debugHud = headsUpDisplay;
+  public void setDebugDisplay(DebugHeadsUpDisplay debugDisplay) {
+    this.debugHud = debugDisplay;
+  }
+
+  /**
+   * Setter for the gameDisplay.
+   * 
+   * @param passedDisplay
+   *          gameDisplay to be set.
+   */
+  public void setHeadsUpDisplay(GameHeadsUpDisplay passedDisplay) {
+    this.gameHud = passedDisplay;
   }
 
   /**

--- a/src/main/java/nl/tudelft/pixelperfect/game/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Game.java
@@ -22,6 +22,7 @@ import nl.tudelft.pixelperfect.event.EventScheduler;
 import nl.tudelft.pixelperfect.gamestates.GameState;
 import nl.tudelft.pixelperfect.gamestates.StartState;
 import nl.tudelft.pixelperfect.gui.DebugHeadsUpDisplay;
+import nl.tudelft.pixelperfect.gui.GameHeadsUpDisplay;
 
 import java.io.IOException;
 
@@ -55,7 +56,8 @@ public class Game extends VRApplication {
 
   private Scene scene;
 
-  private DebugHeadsUpDisplay gameHud;
+  private DebugHeadsUpDisplay debugHud;
+  private GameHeadsUpDisplay gameHud;
 
   private GameState gameState;
 
@@ -123,7 +125,8 @@ public class Game extends VRApplication {
     scheduler.subscribe(spaceship.getLog());
     scheduler.start();
 
-    gameHud = new DebugHeadsUpDisplay(getAssetManager(), guiNode, 200, 200, spaceship);
+    debugHud = new DebugHeadsUpDisplay(getAssetManager(), guiNode, 200, 200, spaceship);
+    gameHud = new GameHeadsUpDisplay(getAssetManager(), guiNode, 900, 900, spaceship);
 
     gameState = new StartState(this);
   }
@@ -285,7 +288,7 @@ public class Game extends VRApplication {
    * @return gameHud
    */
   public DebugHeadsUpDisplay getGameHud() {
-    return gameHud;
+    return debugHud;
   }
 
   /**
@@ -304,7 +307,7 @@ public class Game extends VRApplication {
    *          HeadsUpDisplay to be set.
    */
   public void setHeadsUpDisplay(DebugHeadsUpDisplay headsUpDisplay) {
-    this.gameHud = headsUpDisplay;
+    this.debugHud = headsUpDisplay;
   }
 
   /**

--- a/src/main/java/nl/tudelft/pixelperfect/game/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Game.java
@@ -126,7 +126,7 @@ public class Game extends VRApplication {
     scheduler.start();
 
     debugHud = new DebugHeadsUpDisplay(getAssetManager(), guiNode, 200, 200, spaceship);
-    gameHud = new GameHeadsUpDisplay(getAssetManager(), guiNode, 900, 900, spaceship);
+    gameHud = new GameHeadsUpDisplay(getAssetManager(), guiNode, 1800, 1050, spaceship);
 
     gameState = new StartState(this);
   }
@@ -272,7 +272,7 @@ public class Game extends VRApplication {
   public boolean isDebugOnTrigger() {
     return debugKeyOn;
   }
-  
+
   /**
    * Getter for the debugKey deactivator.
    * 
@@ -283,12 +283,21 @@ public class Game extends VRApplication {
   }
 
   /**
-   * Getter for gameHud.
+   * Getter for the debugHud.
    *
+   * @return debugHud
+   */
+  public DebugHeadsUpDisplay getDebugHud() {
+    return debugHud;
+  }
+
+  /**
+   * Getter for the gameHud.
+   * 
    * @return gameHud
    */
-  public DebugHeadsUpDisplay getGameHud() {
-    return debugHud;
+  public GameHeadsUpDisplay getGameHud() {
+    return gameHud;
   }
 
   /**

--- a/src/main/java/nl/tudelft/pixelperfect/gamestates/PlayState.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gamestates/PlayState.java
@@ -8,6 +8,7 @@ import nl.tudelft.pixelperfect.game.Game;
 import nl.tudelft.pixelperfect.game.Settings;
 import nl.tudelft.pixelperfect.game.Spaceship;
 import nl.tudelft.pixelperfect.gui.DebugHeadsUpDisplay;
+import nl.tudelft.pixelperfect.gui.GameHeadsUpDisplay;
 
 /**
  * State for when you are playing the game.
@@ -20,6 +21,7 @@ public class PlayState extends GameState {
   private Spatial observer;
   private Spaceship spaceship;
   private DebugHeadsUpDisplay debugDisplay;
+  private GameHeadsUpDisplay gameDisplay;
   private EventScheduler scheduler;
 
   /**
@@ -32,7 +34,8 @@ public class PlayState extends GameState {
     super(game);
     observer = game.getGameObserver();
     spaceship = game.getSpaceship();
-    debugDisplay = game.getGameHud();
+    debugDisplay = game.getDebugHud();
+    gameDisplay = game.getGameHud();
     scheduler = game.getScheduler();
   }
 
@@ -47,6 +50,9 @@ public class PlayState extends GameState {
 
     scheduler.update(tpf);
     spaceship.update(tpf);
+    
+    // Refresh the game HUD.
+    gameDisplay.updateHud();
 
     // If debug mode is enabled, activate the debug update.
     if (Settings.isDebug()) {

--- a/src/main/java/nl/tudelft/pixelperfect/gui/DebugHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/DebugHeadsUpDisplay.java
@@ -33,7 +33,7 @@ public class DebugHeadsUpDisplay {
   private BitmapText timeLeft;
 
   /**
-   * Constructor for the heads-up display for in-game utilization.
+   * Constructor for the debug heads-up display for in-game utilization.
    * 
    * @param passedMan
    *          the passed assetmanager.

--- a/src/main/java/nl/tudelft/pixelperfect/gui/DebugHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/DebugHeadsUpDisplay.java
@@ -81,21 +81,21 @@ public class DebugHeadsUpDisplay {
 
     // Init for the log text, including font loading and text setting.
     captainLog = new BitmapText(hudFont, true);
-    captainLog.setLocalTranslation(screenWidth - Constants.GUI_LOG_WIDTH_OFFSET,
-        screenHeight - Constants.GUI_LOG_HEIGHT_OFFSET, 0);
+    captainLog.setLocalTranslation(screenWidth - Constants.DEBUG_LOG_WIDTH_OFFSET,
+        screenHeight - Constants.DEBUG_LOG_HEIGHT_OFFSET, 0);
 
     // Init for the HUD text, including font loading and text setting.
     shipHealth = new BitmapText(hudFont, true);
-    shipHealth.setLocalTranslation(screenWidth + 150 - Constants.GUI_HEALTH_WIDTH_OFFSET,
-        screenHeight - Constants.GUI_HEALTH_HEIGHT_OFFSET, 0);
+    shipHealth.setLocalTranslation(screenWidth + 150 - Constants.DEBUG_HEALTH_WIDTH_OFFSET,
+        screenHeight - Constants.DEBUG_HEALTH_HEIGHT_OFFSET, 0);
 
     teamScore = new BitmapText(hudFont, true);
-    teamScore.setLocalTranslation(screenWidth + 250 - Constants.GUI_SCORE_WIDTH_OFFSET,
-        screenHeight - Constants.GUI_SCORE_HEIGHT_OFFSET, 0);
+    teamScore.setLocalTranslation(screenWidth + 250 - Constants.DEBUG_SCORE_WIDTH_OFFSET,
+        screenHeight - Constants.DEBUG_SCORE_HEIGHT_OFFSET, 0);
 
     timeLeft = new BitmapText(hudFont, true);
-    timeLeft.setLocalTranslation(screenWidth + 250 - Constants.GUI_TIME_WIDTH_OFFSET,
-        screenHeight - Constants.GUI_TIME_HEIGHT_OFFSET, 0);
+    timeLeft.setLocalTranslation(screenWidth + 250 - Constants.DEBUG_TIME_WIDTH_OFFSET,
+        screenHeight - Constants.DEBUG_TIME_HEIGHT_OFFSET, 0);
   }
 
   /**
@@ -113,19 +113,19 @@ public class DebugHeadsUpDisplay {
 
     // Update the captain's log.
     if (currentEventsToDisplay.isEmpty()) {
-      captainLog.setText(Constants.NO_EVENTS_LOG_TEXT);
+      captainLog.setText(Constants.DEBUG_NO_EVENTS_LOG_TEXT);
     } else {
       captainLog.setText(currentEventsToDisplay.toString());
     }
 
     // Update the ship's health, team score, and time left indicators.
-    shipHealth.setText(Constants.SHIP_HEALTH_LABEL + spaceship.getHealth());
-    teamScore.setText(Constants.SHIP_SCORE_LABEL + spaceship.getScore());
-    timeLeft.setText(Constants.SHIP_TIME_LABEL + spaceship.getTimer());
+    shipHealth.setText(Constants.DEBUG_SHIP_HEALTH_LABEL + spaceship.getHealth());
+    teamScore.setText(Constants.DEBUG_SHIP_SCORE_LABEL + spaceship.getScore());
+    timeLeft.setText(Constants.DEBUG_SHIP_TIME_LABEL + spaceship.getTimer());
   }
 
   /**
-   * Clears the debug display after de-activation.
+   * Clears the debug display after de-activation of the debug mode.
    */
   public void clearHud() {
     captainLog.setText("");

--- a/src/main/java/nl/tudelft/pixelperfect/gui/DebugHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/DebugHeadsUpDisplay.java
@@ -59,7 +59,7 @@ public class DebugHeadsUpDisplay {
   }
 
   /**
-   * Sets-up text display for the in-game HUD, along with all of its elements.
+   * Sets-up text display for the in-game debug HUD, along with all of its elements.
    */
   private void setupTextDisplay() {
     // Set-up the bitmap text needed for HUD display.
@@ -73,7 +73,7 @@ public class DebugHeadsUpDisplay {
   }
 
   /**
-   * Set-up the bitmap associations for the HUD text.
+   * Set-up the bitmap associations for the debug HUD text.
    */
   private void setUpBitmapText() {
     // Loading the font stored in the jme default manager.
@@ -99,8 +99,8 @@ public class DebugHeadsUpDisplay {
   }
 
   /**
-   * Method responsible for the updating of the hud text and displaying the events, along with their
-   * remaining time and health, and other HUD elements.
+   * Method responsible for the updating of the debug hud text and displaying the events, along with
+   * their remaining time and health, and other HUD elements.
    */
   public void updateHud() {
     ArrayList<Event> currentEvents = spaceship.getLog().getEvents();

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -1,7 +1,5 @@
 package nl.tudelft.pixelperfect.gui;
 
-import java.util.ArrayList;
-
 import com.jme3.asset.AssetManager;
 import com.jme3.font.BitmapFont;
 import com.jme3.font.BitmapText;
@@ -11,6 +9,8 @@ import com.jme3.scene.Node;
 import nl.tudelft.pixelperfect.event.Event;
 import nl.tudelft.pixelperfect.game.Constants;
 import nl.tudelft.pixelperfect.game.Spaceship;
+
+import java.util.ArrayList;
 
 /**
  * Class responsible for the display, refreshing, and functionality of the heads-up display (HUD)
@@ -101,6 +101,7 @@ public class GameHeadsUpDisplay {
     shipHealth.setText("" + spaceship.getHealth());
     teamScore.setText("" + spaceship.getScore());
     
+    // Array lists to store the events.
     ArrayList<Event> currentEventsArray = spaceship.getLog().getEvents();
     ArrayList<String> currentEventsToDisplay = new ArrayList<String>();
 
@@ -109,9 +110,9 @@ public class GameHeadsUpDisplay {
       currentEventsToDisplay.add(current.toDebugString());
     }
 
-    // Update the captain's log.
+    // Update the active event log.
     if (currentEventsToDisplay.isEmpty()) {
-      currentEvents.setText(Constants.DEBUG_NO_EVENTS_LOG_TEXT);
+      currentEvents.setText("");
     } else {
       currentEvents.setText(currentEventsToDisplay.toString());
     }

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -109,9 +109,14 @@ public class GameHeadsUpDisplay {
       currentEvents.setText("");
     } else {
       String toDisplay = "";
+      ArrayList<String> preventCopy = new ArrayList<String>();
 
+      // Loop through all the events to display them in the HUD.
       for (Event current : currentEventsArray) {
-        toDisplay = toDisplay + current.getDescription() + "\n";
+        if (!preventCopy.contains(current.getSummary())) {
+          toDisplay = toDisplay + current.getDescription() + "\n";
+          preventCopy.add(current.getSummary());
+        }
       }
 
       currentEvents.setText(toDisplay);

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -69,7 +69,9 @@ public class GameHeadsUpDisplay {
 
     // Init for the log text, including font loading and text setting.
     currentEvents = new BitmapText(hudFont, true);
-    currentEvents.setLocalTranslation(screenWidth, screenHeight, 0);
+    currentEvents.setColor(ColorRGBA.LightGray);
+    currentEvents.setLocalTranslation(screenWidth - Constants.GUI_LOG_WIDTH_OFFSET,
+        screenHeight - Constants.GUI_LOG_HEIGHT_OFFSET, 0);
 
     // Init for the health text, including font loading and text setting.
     shipHealth = new BitmapText(hudFont, true);

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -108,18 +108,18 @@ public class GameHeadsUpDisplay {
     if (currentEventsArray.isEmpty()) {
       currentEvents.setText("");
     } else {
-      String toDisplay = "";
+      StringBuilder toDisplay = new StringBuilder();
       ArrayList<String> preventCopy = new ArrayList<String>();
 
       // Loop through all the events to display them in the HUD.
       for (Event current : currentEventsArray) {
         if (!preventCopy.contains(current.getSummary())) {
-          toDisplay = toDisplay + current.getDescription() + "\n";
+          toDisplay.append(current.getDescription() + "\n");
           preventCopy.add(current.getSummary());
         }
       }
 
-      currentEvents.setText(toDisplay);
+      currentEvents.setText(toDisplay.toString());
     }
   }
 }

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -97,8 +97,23 @@ public class GameHeadsUpDisplay {
    * remaining time and health, and other HUD elements.
    */
   public void updateHud() {
-    // Update the ship's health, team score, and time left indicators.
+    // Update the ship's health and team score indicators.
     shipHealth.setText("" + spaceship.getHealth());
     teamScore.setText("" + spaceship.getScore());
+    
+    ArrayList<Event> currentEventsArray = spaceship.getLog().getEvents();
+    ArrayList<String> currentEventsToDisplay = new ArrayList<String>();
+
+    // Fetch all event times for updates and display.
+    for (Event current : currentEventsArray) {
+      currentEventsToDisplay.add(current.toDebugString());
+    }
+
+    // Update the captain's log.
+    if (currentEventsToDisplay.isEmpty()) {
+      currentEvents.setText(Constants.DEBUG_NO_EVENTS_LOG_TEXT);
+    } else {
+      currentEvents.setText(currentEventsToDisplay.toString());
+    }
   }
 }

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -75,7 +75,8 @@ public class GameHeadsUpDisplay {
     shipHealth = new BitmapText(hudFont, true);
     shipHealth.setLocalScale(Constants.GUI_HEALTH_TEXT_SIZE_SCALE);
     shipHealth.setColor(ColorRGBA.Red);
-    shipHealth.setLocalTranslation(screenWidth, screenHeight, 0);
+    shipHealth.setLocalTranslation(screenWidth - Constants.GUI_HEALTH_WIDTH_OFFSET, screenHeight,
+        0);
 
     // Init for the score text, including font loading and text setting.
     teamScore = new BitmapText(hudFont, true);

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -1,0 +1,12 @@
+package nl.tudelft.pixelperfect.gui;
+
+/**
+ * Class responsible for the display, refreshing, and functionality of the heads-up display (HUD)
+ * that is displayed during the active gameplay for the Client.
+ * 
+ * @author David Alderliesten
+ *
+ */
+public class GameHeadsUpDisplay {
+
+}

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -67,20 +67,20 @@ public class GameHeadsUpDisplay {
     // Loading the font stored in the jme default manager.
     hudFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
 
-    // Init for the log text, including font loading and text setting.
+    // Initializer for the log text, including font loading and text setting.
     currentEvents = new BitmapText(hudFont, true);
     currentEvents.setColor(ColorRGBA.LightGray);
-    currentEvents.setLocalTranslation(screenWidth - Constants.GUI_LOG_WIDTH_OFFSET,
-        screenHeight - Constants.GUI_LOG_HEIGHT_OFFSET, 0);
+    currentEvents.setLocalTranslation(screenWidth - Constants.GUI_LOG_WIDTH_OFFSET, screenHeight,
+        0);
 
-    // Init for the health text, including font loading and text setting.
+    // Initializer for the health text, including font loading and text setting.
     shipHealth = new BitmapText(hudFont, true);
     shipHealth.setLocalScale(Constants.GUI_HEALTH_TEXT_SIZE_SCALE);
     shipHealth.setColor(ColorRGBA.Red);
     shipHealth.setLocalTranslation(screenWidth - Constants.GUI_HEALTH_WIDTH_OFFSET, screenHeight,
         0);
 
-    // Init for the score text, including font loading and text setting.
+    // Initializer for the score text, including font loading and text setting.
     teamScore = new BitmapText(hudFont, true);
     teamScore.setLocalScale(Constants.GUI_SCORE_TEXT_SIZE_SCALE);
     teamScore.setColor(ColorRGBA.Green);
@@ -100,21 +100,21 @@ public class GameHeadsUpDisplay {
     // Update the ship's health and team score indicators.
     shipHealth.setText("" + spaceship.getHealth());
     teamScore.setText("" + spaceship.getScore());
-    
+
     // Array lists to store the events.
     ArrayList<Event> currentEventsArray = spaceship.getLog().getEvents();
-    ArrayList<String> currentEventsToDisplay = new ArrayList<String>();
-
-    // Fetch all event times for updates and display.
-    for (Event current : currentEventsArray) {
-      currentEventsToDisplay.add(current.toDebugString());
-    }
 
     // Update the active event log.
-    if (currentEventsToDisplay.isEmpty()) {
+    if (currentEventsArray.isEmpty()) {
       currentEvents.setText("");
     } else {
-      currentEvents.setText(currentEventsToDisplay.toString());
+      String toDisplay = "";
+
+      for (Event current : currentEventsArray) {
+        toDisplay = toDisplay + current.getDescription() + "\n";
+      }
+
+      currentEvents.setText(toDisplay);
     }
   }
 }

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import com.jme3.asset.AssetManager;
 import com.jme3.font.BitmapFont;
 import com.jme3.font.BitmapText;
+import com.jme3.math.ColorRGBA;
 import com.jme3.scene.Node;
 
 import nl.tudelft.pixelperfect.event.Event;
@@ -72,12 +73,14 @@ public class GameHeadsUpDisplay {
 
     // Init for the health text, including font loading and text setting.
     shipHealth = new BitmapText(hudFont, true);
-    shipHealth.setLocalScale(10);
+    shipHealth.setLocalScale(Constants.GUI_HEALTH_TEXT_SIZE_SCALE);
+    shipHealth.setColor(ColorRGBA.Red);
     shipHealth.setLocalTranslation(screenWidth, screenHeight, 0);
 
     // Init for the score text, including font loading and text setting.
     teamScore = new BitmapText(hudFont, true);
-    teamScore.setLocalScale(10);
+    teamScore.setLocalScale(Constants.GUI_SCORE_TEXT_SIZE_SCALE);
+    teamScore.setColor(ColorRGBA.Green);
     teamScore.setLocalTranslation(screenWidth, screenHeight, 0);
 
     // Add the generated bitmaps to the gui node view.

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -5,6 +5,7 @@ import com.jme3.font.BitmapFont;
 import com.jme3.font.BitmapText;
 import com.jme3.scene.Node;
 
+import nl.tudelft.pixelperfect.game.Constants;
 import nl.tudelft.pixelperfect.game.Spaceship;
 
 /**
@@ -59,7 +60,25 @@ public class GameHeadsUpDisplay {
    * guiNodes.
    */
   private void setupFont() {
+    // Loading the font stored in the jme default manager.
+    hudFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
 
+    // Init for the log text, including font loading and text setting.
+    currentEvents = new BitmapText(hudFont, true);
+    currentEvents.setLocalTranslation(screenWidth, screenHeight, 0);
+
+    // Init for the health text, including font loading and text setting.
+    shipHealth = new BitmapText(hudFont, true);
+    shipHealth.setLocalTranslation(screenWidth, screenHeight, 0);
+
+    // Init for the score text, including font loading and text setting.
+    teamScore = new BitmapText(hudFont, true);
+    teamScore.setLocalTranslation(screenWidth, screenHeight, 0);
+
+    // Add the generated bitmaps to the gui node view.
+    guiNodes.attachChild(currentEvents);
+    guiNodes.attachChild(shipHealth);
+    guiNodes.attachChild(teamScore);
   }
 
 }

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -1,12 +1,65 @@
 package nl.tudelft.pixelperfect.gui;
 
+import com.jme3.asset.AssetManager;
+import com.jme3.font.BitmapFont;
+import com.jme3.font.BitmapText;
+import com.jme3.scene.Node;
+
+import nl.tudelft.pixelperfect.game.Spaceship;
+
 /**
  * Class responsible for the display, refreshing, and functionality of the heads-up display (HUD)
- * that is displayed during the active gameplay for the Client.
+ * that is displayed during the active gameplay for the Client. Score and Ship health are displayed
+ * constantly, and the current events are shown when they arise.
  * 
  * @author David Alderliesten
  *
  */
 public class GameHeadsUpDisplay {
+  private Spaceship spaceship;
+
+  private AssetManager assetManager;
+  private Node guiNodes;
+  private int screenWidth;
+  private int screenHeight;
+
+  private BitmapFont hudFont;
+  private BitmapText currentEvents;
+  private BitmapText shipHealth;
+  private BitmapText teamScore;
+
+  /**
+   * Constructor for the heads-up display for in-game utilization and display.
+   * 
+   * @param passedMan
+   *          the passed assetmanager.
+   * @param passedGuiNode
+   *          the passed gui node.
+   * @param passedWid
+   *          the passed screen width.
+   * @param passedHi
+   *          the passed screen height.
+   * @param passedShip
+   *          the passed Spaceship instance.
+   */
+  public GameHeadsUpDisplay(AssetManager passedMan, Node passedGuiNode, int passedWid, int passedHi,
+      Spaceship passedShip) {
+    this.assetManager = passedMan;
+    this.guiNodes = passedGuiNode;
+    this.screenWidth = passedWid;
+    this.screenHeight = passedHi;
+    this.spaceship = passedShip;
+
+    // Setting-up the fonts required for the Bitmap display.
+    setupFont();
+  }
+
+  /**
+   * Private class responsible for setting-up the bitmap fonts and attaching the HUD elements to the
+   * guiNodes.
+   */
+  private void setupFont() {
+
+  }
 
 }

--- a/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gui/GameHeadsUpDisplay.java
@@ -1,10 +1,13 @@
 package nl.tudelft.pixelperfect.gui;
 
+import java.util.ArrayList;
+
 import com.jme3.asset.AssetManager;
 import com.jme3.font.BitmapFont;
 import com.jme3.font.BitmapText;
 import com.jme3.scene.Node;
 
+import nl.tudelft.pixelperfect.event.Event;
 import nl.tudelft.pixelperfect.game.Constants;
 import nl.tudelft.pixelperfect.game.Spaceship;
 
@@ -69,10 +72,12 @@ public class GameHeadsUpDisplay {
 
     // Init for the health text, including font loading and text setting.
     shipHealth = new BitmapText(hudFont, true);
+    shipHealth.setLocalScale(10);
     shipHealth.setLocalTranslation(screenWidth, screenHeight, 0);
 
     // Init for the score text, including font loading and text setting.
     teamScore = new BitmapText(hudFont, true);
+    teamScore.setLocalScale(10);
     teamScore.setLocalTranslation(screenWidth, screenHeight, 0);
 
     // Add the generated bitmaps to the gui node view.
@@ -81,4 +86,13 @@ public class GameHeadsUpDisplay {
     guiNodes.attachChild(teamScore);
   }
 
+  /**
+   * Method responsible for the updating of the hud text and displaying the events, along with their
+   * remaining time and health, and other HUD elements.
+   */
+  public void updateHud() {
+    // Update the ship's health, team score, and time left indicators.
+    shipHealth.setText("" + spaceship.getHealth());
+    teamScore.setText("" + spaceship.getScore());
+  }
 }

--- a/src/test/java/nl/tudelft/pixelperfect/gamestates/PlayStateTest.java
+++ b/src/test/java/nl/tudelft/pixelperfect/gamestates/PlayStateTest.java
@@ -14,6 +14,7 @@ import nl.tudelft.pixelperfect.game.Game;
 import nl.tudelft.pixelperfect.game.Settings;
 import nl.tudelft.pixelperfect.game.Spaceship;
 import nl.tudelft.pixelperfect.gui.DebugHeadsUpDisplay;
+import nl.tudelft.pixelperfect.gui.GameHeadsUpDisplay;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -33,7 +34,8 @@ public class PlayStateTest extends GameStateTest {
   private Spatial mockObserver;
   private EventScheduler mockScheduler;
   private Spaceship mockSpaceship;
-  private DebugHeadsUpDisplay mockHeadsUp;
+  private DebugHeadsUpDisplay mockDebugUp;
+  private GameHeadsUpDisplay mockHeadsUp;
   private Settings testSettings;
 
   /**
@@ -45,11 +47,13 @@ public class PlayStateTest extends GameStateTest {
     mockScheduler = mock(EventScheduler.class);
     mockObserver = mock(Spatial.class);
     mockSpaceship = mock(Spaceship.class);
-    mockHeadsUp = mock(DebugHeadsUpDisplay.class);
+    mockDebugUp = mock(DebugHeadsUpDisplay.class);
+    mockHeadsUp = mock(GameHeadsUpDisplay.class);
     mockGame.setGameObserver(mockObserver);
     mockGame.setScheduler(mockScheduler);
     mockGame.setSpaceship(mockSpaceship);
     mockGame.setHeadsUpDisplay(mockHeadsUp);
+    mockGame.setDebugDisplay(mockDebugUp);
     testSettings = Settings.getInstance();
     testState = new PlayState(mockGame);
   }
@@ -60,11 +64,12 @@ public class PlayStateTest extends GameStateTest {
   @Test
   public void testUpdate() {
     testSettings.setIsDebug(true);
-    
+
     testState.update(1f);
     verify(mockScheduler).update(1f);
     verify(mockSpaceship).update(anyFloat());
     verify(mockHeadsUp).updateHud();
+    verify(mockDebugUp).updateHud();
   }
 
   /**
@@ -73,12 +78,13 @@ public class PlayStateTest extends GameStateTest {
   @Test
   public void testUpdateWithoutDebug() {
     testSettings.setIsDebug(false);
-    
+
     testState.update(1f);
     verify(mockScheduler).update(1f);
     verify(mockSpaceship).update(anyFloat());
-    
-    verify(mockHeadsUp, Mockito.times(0)).updateHud();
+    verify(mockHeadsUp).updateHud();
+
+    verify(mockDebugUp, Mockito.times(0)).updateHud();
   }
 
   /**


### PR DESCRIPTION
Created the official beta HUD, to be used for beta presentation and final HUD development.  The HUD does not scale, but assume the player is full-screen on the resolution of an Oculus Rift or an HD display.  

The HUD displays the score, health, and the current event's information/hint.  It will only display each event type once, so communication is of the essence.  Debug mode can still be found with 0 for on and 1 for off.

Final issues for next sprint:

-Adapt to screen size.
-Remove the event log's exact information and replace it with location queues.