### PR TITLE
Implemented role chosen sync in an existing game.

### DIFF
--- a/src/main/java/nl/tudelft/pixelperfect/client/ServerListener.java
+++ b/src/main/java/nl/tudelft/pixelperfect/client/ServerListener.java
@@ -29,7 +29,7 @@ public class ServerListener implements MessageListener<HostedConnection> {
 
   private Game app;
   private Server server;
-  private ArrayList<Roles> roles;
+  private ArrayList<Roles> roles = new ArrayList<Roles>();
 
   /**
    * Sets the game whose server to listen for.

--- a/src/main/java/nl/tudelft/pixelperfect/client/ServerListener.java
+++ b/src/main/java/nl/tudelft/pixelperfect/client/ServerListener.java
@@ -15,6 +15,7 @@ import nl.tudelft.pixelperfect.client.message.RoleChosenMessage;
 import nl.tudelft.pixelperfect.event.parameter.EventParameter;
 import nl.tudelft.pixelperfect.event.type.EventTypes;
 import nl.tudelft.pixelperfect.game.Game;
+import nl.tudelft.pixelperfect.game.Roles;
 
 /**
  * Listener for the Game's server, which handles incoming messages.
@@ -28,6 +29,7 @@ public class ServerListener implements MessageListener<HostedConnection> {
 
   private Game app;
   private Server server;
+  private ArrayList<Roles> roles;
 
   /**
    * Sets the game whose server to listen for.
@@ -72,7 +74,17 @@ public class ServerListener implements MessageListener<HostedConnection> {
       EventCompletedMessage completedMessage = (EventCompletedMessage) message;
       processEventCompletedMessage(completedMessage);
     } else if (message instanceof RoleChosenMessage) {
-      server.broadcast(Filters.notEqualTo(source), message);
+      RoleChosenMessage retrieved = (RoleChosenMessage) message;
+      if (retrieved.isEmpty()) {
+        for (Roles role : roles) {
+          server.broadcast(Filters.equalTo(source), new RoleChosenMessage("initial roles chosen",
+              role));
+        }
+      } else {
+        roles.add(retrieved.getRole());
+        server.broadcast(Filters.notEqualTo(source), message);
+      }
+
     }
   }
 

--- a/src/main/java/nl/tudelft/pixelperfect/client/message/RoleChosenMessage.java
+++ b/src/main/java/nl/tudelft/pixelperfect/client/message/RoleChosenMessage.java
@@ -15,12 +15,13 @@ import nl.tudelft.pixelperfect.game.Roles;
 public class RoleChosenMessage extends AbstractMessage {
   private Roles role;
   private String label;
+  private Boolean isEmpty;
 
   /**
    * The empty Constructor.
    */
   public RoleChosenMessage() {
-
+    this.isEmpty = true;
   }
 
   /**
@@ -34,6 +35,7 @@ public class RoleChosenMessage extends AbstractMessage {
   public RoleChosenMessage(String label, Roles role) {
     this.role = role;
     this.label = label;
+    this.isEmpty = false;
   }
 
   /**
@@ -52,6 +54,16 @@ public class RoleChosenMessage extends AbstractMessage {
    */
   public Roles getRole() {
     return role;
+  }
+
+  /**
+   * Returns whether the message is empty or not. If the message is empty it is likely to be used
+   * for sending back all roles chosen.
+   * 
+   * @return a boolean.
+   */
+  public Boolean isEmpty() {
+    return isEmpty;
   }
 
 }


### PR DESCRIPTION
Whenever the client reconnects the list of roles must be made clear before choosing one.

Comes with Client PR: https://github.com/jessetilro/pixelperfect-client/pull/37