### PR TITLE
Only notify the first event of each type

### DIFF
--- a/src/main/java/nl/tudelft/pixelperfect/event/EventListener.java
+++ b/src/main/java/nl/tudelft/pixelperfect/event/EventListener.java
@@ -10,6 +10,7 @@ import nl.tudelft.pixelperfect.event.type.EventTypes;
  * Interface for classes that can subscribe themselves to an EventScheduler.
  * 
  * @author Jesse Tilro
+ * @author Wouter Zirkzee
  *
  */
 public interface EventListener {
@@ -45,6 +46,15 @@ public interface EventListener {
    *          The submitted parameters.
    */
   void complete(EventTypes type, Collection<EventParameter> parameters);
+
+
+  /**
+   * Get first event of specified type.
+   * @param type
+   *            type to find.
+   * @return event of given type
+   */
+  Event getFirst(EventTypes type);
 
   /**
    * Get all the events that are in the log.

--- a/src/main/java/nl/tudelft/pixelperfect/event/EventLog.java
+++ b/src/main/java/nl/tudelft/pixelperfect/event/EventLog.java
@@ -12,6 +12,7 @@ import nl.tudelft.pixelperfect.game.Spaceship;
  * 
  * @author David Alderliesten
  * @author Jesse Tilro
+ * @author Wouter Zirkzee
  *
  */
 public class EventLog implements EventListener {
@@ -145,5 +146,20 @@ public class EventLog implements EventListener {
       event.applyDamage(spaceship);
       discard(event);
     }
+  }
+
+  /**
+   * Get first event of specified type.
+   * @param type
+   *            type to find.
+   * @return event of given type
+   */
+  public Event getFirst(EventTypes type) {
+    for (Event event: events) {
+      if (event.getType().equals(type)) {
+        return event;
+      }
+    }
+    return null;
   }
 }

--- a/src/main/java/nl/tudelft/pixelperfect/gamestates/PlayState.java
+++ b/src/main/java/nl/tudelft/pixelperfect/gamestates/PlayState.java
@@ -5,6 +5,7 @@ import jmevr.app.VRApplication;
 
 import nl.tudelft.pixelperfect.event.Event;
 import nl.tudelft.pixelperfect.event.EventScheduler;
+import nl.tudelft.pixelperfect.event.type.EventTypes;
 import nl.tudelft.pixelperfect.game.Game;
 import nl.tudelft.pixelperfect.game.Settings;
 import nl.tudelft.pixelperfect.game.Spaceship;
@@ -64,8 +65,11 @@ public class PlayState extends GameState {
       debugDisplay.clearHud();
     }
 
-    for (Event event: spaceship.getLog().getEvents()) {
-      event.notification(game, game.getScene());
+    for (EventTypes eventType : EventTypes.values()) {
+      Event event = spaceship.getLog().getFirst(eventType);
+      if (event != null) {
+        event.notification(game, game.getScene());
+      }
     }
   }
 

--- a/src/test/java/nl/tudelft/pixelperfect/event/EventLogTest.java
+++ b/src/test/java/nl/tudelft/pixelperfect/event/EventLogTest.java
@@ -26,6 +26,7 @@ import nl.tudelft.pixelperfect.game.Spaceship;
  * 
  * @author David Alderliesten
  * @author Jesse Tilro
+ * @author Wouter Zirkzee
  *
  */
 @SuppressWarnings("PMD")
@@ -160,5 +161,39 @@ public class EventLogTest extends EventListenerTest {
     assertFalse(log.contains(evt1));
     assertTrue(log.contains(evt2));
     verify(mockedSpaceship).updateHealth(-50);
+  }
+
+  /**
+   * Test that the method actually gets the first object
+   */
+  @Test
+  public void testGetFirst() {
+    Event evt1 = new FireOutbreakEvent(0, "Mango", "Pineapple", 0, 0, 50);
+    Event evt2 = new FireOutbreakEvent(1, "Pear", "Kiwi Fruit", System.currentTimeMillis(),
+        99999999, 50);
+    ArrayList<Event> events = object.getEvents();
+    events.add(evt1);
+    events.add(evt2);
+
+    Event testEvent = object.getFirst(EventTypes.FIRE_OUTBREAK);
+
+    assertEquals(testEvent, evt1);
+  }
+
+  /**
+   * Test that the method returns null when the type is not in the log.
+   */
+  @Test
+  public void testGetFirstNull() {
+    Event evt1 = new FireOutbreakEvent(0, "Mango", "Pineapple", 0, 0, 50);
+    Event evt2 = new FireOutbreakEvent(1, "Pear", "Kiwi Fruit", System.currentTimeMillis(),
+        99999999, 50);
+    ArrayList<Event> events = object.getEvents();
+    events.add(evt1);
+    events.add(evt2);
+
+    Event testEvent = object.getFirst(EventTypes.ASTEROID_IMPACT);
+
+    assertEquals(testEvent, null);
   }
 }


### PR DESCRIPTION
small change in the way events are notified, now only first event gets notified (which is also the first to expire since times are equal for each event).