### PR TITLE
Tweak event scheduling

### DIFF
--- a/src/main/java/nl/tudelft/pixelperfect/client/message/RoleChosenMessage.java
+++ b/src/main/java/nl/tudelft/pixelperfect/client/message/RoleChosenMessage.java
@@ -13,7 +13,7 @@ import nl.tudelft.pixelperfect.player.PlayerRoles;
  */
 @Serializable
 public class RoleChosenMessage extends AbstractMessage {
-  private PlayerRoles role;
+  private int role;
   private boolean allocated;
 
   /**
@@ -31,7 +31,7 @@ public class RoleChosenMessage extends AbstractMessage {
    *          Allocated.
    */
   public RoleChosenMessage(PlayerRoles role, boolean allocated) {
-    this.role = role;
+    this.role = role.ordinal();
     this.allocated = allocated;
   }
 
@@ -41,7 +41,7 @@ public class RoleChosenMessage extends AbstractMessage {
    * @return role as an Enum.
    */
   public PlayerRoles getRole() {
-    return role;
+    return PlayerRoles.values()[role];
   }
 
   /**

--- a/src/main/java/nl/tudelft/pixelperfect/event/EventLog.java
+++ b/src/main/java/nl/tudelft/pixelperfect/event/EventLog.java
@@ -69,14 +69,17 @@ public class EventLog implements EventListener {
   }
 
   /**
-   * Be notified of a new event by a scheduler.
+   * Be notified of a new event by a scheduler. The Event will only be added to the log is there is
+   * player in the crew who can solve this type of Event.
    * 
    * @param event
    *          The event that the scheduler introduces, to be listed in the log.
    */
   public synchronized void notify(Event event) {
-    events.add(event);
-    System.out.println("The ship received a new event: " + event.getSummary());
+    if (spaceship.getCrew().hasPlayerWhoCanSolveEvent(event)) {
+      events.add(event);
+      System.out.println("The ship received a new event: " + event.getSummary());
+    }
   }
 
   /**
@@ -129,8 +132,8 @@ public class EventLog implements EventListener {
     if (candidates.size() > 0) {
       System.out.println("Wrong task performed: wrong parameters entered");
     } else {
-      System.out.println("Wrong task performed: there is no active Event of type "
-          + type.toString());
+      System.out
+          .println("Wrong task performed: there is no active Event of type " + type.toString());
     }
 
     spaceship.updateHealth(-10);

--- a/src/main/java/nl/tudelft/pixelperfect/game/Game.java
+++ b/src/main/java/nl/tudelft/pixelperfect/game/Game.java
@@ -28,6 +28,7 @@ import nl.tudelft.pixelperfect.gamestates.GameState;
 import nl.tudelft.pixelperfect.gamestates.StartState;
 import nl.tudelft.pixelperfect.gui.DebugHeadsUpDisplay;
 import nl.tudelft.pixelperfect.gui.GameHeadsUpDisplay;
+import nl.tudelft.pixelperfect.player.PlayerRoles;
 
 /**
  * Main class representing an active Game process and creating the JMonkey Environment. Suppressing

--- a/src/main/java/nl/tudelft/pixelperfect/player/Player.java
+++ b/src/main/java/nl/tudelft/pixelperfect/player/Player.java
@@ -2,6 +2,8 @@ package nl.tudelft.pixelperfect.player;
 
 import com.jme3.network.HostedConnection;
 
+import nl.tudelft.pixelperfect.event.Event;
+
 /**
  * A player fulfilling a role aboard of the spaceship while playing the game.
  * 
@@ -69,6 +71,16 @@ public abstract class Player {
    */
   public void assignRole(PlayerRoles role) {
     this.role = role;
+  }
+
+  /**
+   * Check whether this Player is able to solve a specific Event (based on whether the Player's role
+   * is able to solve the type of Event).
+   * 
+   * @return Whether this Player can solve an Event.
+   */
+  public boolean canSolveEvent(Event event) {
+    return (role != null && role.canSolveEventType(event.getType()));
   }
 
   /**

--- a/src/main/java/nl/tudelft/pixelperfect/player/PlayerCollection.java
+++ b/src/main/java/nl/tudelft/pixelperfect/player/PlayerCollection.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import com.jme3.network.HostedConnection;
 
+import nl.tudelft.pixelperfect.event.Event;
+
 /**
  * Aggregates the (crew) players currently playing the game.
  * 
@@ -37,7 +39,7 @@ public class PlayerCollection {
    * 
    * @param connection
    *          The connection through which the player is connected to the game.
-   *          
+   * 
    * @return The Player with the given connection.
    */
   public synchronized Player getPlayerByConnection(HostedConnection connection) {
@@ -79,6 +81,22 @@ public class PlayerCollection {
    */
   public synchronized boolean hasPlayerWithRole(PlayerRoles role) {
     return (getPlayerByRole(role) != null);
+  }
+
+  /**
+   * Check whether this collection contains a Player who can solve a given Event.
+   * 
+   * @param event
+   *          The Event to be solved.
+   * @return Whether there is a Player who can solve the Event.
+   */
+  public synchronized boolean hasPlayerWhoCanSolveEvent(Event event) {
+    for (Player player : map.values()) {
+      if (player.canSolveEvent(event)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/main/java/nl/tudelft/pixelperfect/player/PlayerRoles.java
+++ b/src/main/java/nl/tudelft/pixelperfect/player/PlayerRoles.java
@@ -1,10 +1,53 @@
 package nl.tudelft.pixelperfect.player;
 
+import java.util.Arrays;
+import java.util.List;
+
+import nl.tudelft.pixelperfect.event.type.EventTypes;
+
 /**
  * Enums representing the roles in the game.
  * 
  * @author Floris Doolaard
+ * @author Jesse Tilro
  */
 public enum PlayerRoles {
-  GUNNER, ENGINEER, SCIENTIST, JANITOR
+  GUNNER {
+    public List<EventTypes> getEventTypesSolved() {
+      return Arrays.asList(new EventTypes[] { EventTypes.HOSTILE_SHIP, EventTypes.FIRE_OUTBREAK });
+    }
+  },
+  ENGINEER {
+    public List<EventTypes> getEventTypesSolved() {
+      return Arrays.asList(new EventTypes[] { EventTypes.ASTEROID_IMPACT, EventTypes.FIRE_OUTBREAK });
+    }
+  },
+  SCIENTIST {
+    public List<EventTypes> getEventTypesSolved() {
+      return Arrays.asList(new EventTypes[] { EventTypes.PLASMA_LEAK, EventTypes.FIRE_OUTBREAK });
+    }
+  },
+  JANITOR {
+    public List<EventTypes> getEventTypesSolved() {
+      return Arrays.asList(new EventTypes[] { EventTypes.COFFEE_BOOST, EventTypes.FIRE_OUTBREAK });
+    }
+  };
+
+  /**
+   * Get a list over EventTypes a player with this role can solve.
+   * 
+   * @return A list of EventTypes this role can solve.s
+   */
+  public abstract List<EventTypes> getEventTypesSolved();
+
+  /**
+   * Check whether this role is able to solve a given Event type.
+   * 
+   * @param eventType
+   *          The type of Event to be solved.
+   * @return Whether this role can solve the Event.
+   */
+  public boolean canSolveEventType(EventTypes eventType) {
+    return getEventTypesSolved().contains(eventType);
+  }
 }

--- a/src/test/java/nl/tudelft/pixelperfect/event/EventLogTest.java
+++ b/src/test/java/nl/tudelft/pixelperfect/event/EventLogTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,6 +24,7 @@ import nl.tudelft.pixelperfect.event.type.FireOutbreakEvent;
 import nl.tudelft.pixelperfect.event.type.PlasmaLeakEvent;
 import nl.tudelft.pixelperfect.game.Game;
 import nl.tudelft.pixelperfect.game.Spaceship;
+import nl.tudelft.pixelperfect.player.PlayerCollection;
 
 /**
  * Test Suite for the EventLog class.
@@ -36,6 +38,7 @@ import nl.tudelft.pixelperfect.game.Spaceship;
 public class EventLogTest extends EventListenerTest {
   private EventLog object;
   private Spaceship mockedSpaceship;
+  private PlayerCollection mockedCrew;
   private Game mockedGame;
   private AudioPlayer mockedAudio;
 
@@ -45,10 +48,13 @@ public class EventLogTest extends EventListenerTest {
   @Before
   public void initialise() {
     mockedSpaceship = mock(Spaceship.class);
+    mockedCrew = mock(PlayerCollection.class);
     mockedGame = mock(Game.class);
     mockedAudio = mock(AudioPlayer.class);
 
     when(mockedGame.getAudioPlayer()).thenReturn(mockedAudio);
+    when(mockedSpaceship.getCrew()).thenReturn(mockedCrew);
+    when(mockedCrew.hasPlayerWhoCanSolveEvent(any(Event.class))).thenReturn(true);
 
     object = new EventLog(mockedSpaceship);
   }


### PR DESCRIPTION
The EventLog now only allows Events to be added when there is a Player in
the crew who is able (given the player's role and the event's type) to
solve the event.

In parallel with https://github.com/jessetilro/pixelperfect-client/pull/57.